### PR TITLE
Remove variance branch length parameter

### DIFF
--- a/src/chronumental/__main__.py
+++ b/src/chronumental/__main__.py
@@ -86,10 +86,6 @@ def get_parser():
         "Scale factor for date distribution. Essentially a measure of how uncertain we think the measured dates are."
     )
 
-    parser.add_argument('--variance_branch_length',
-                        default=10,
-                        type=float,
-                        help="Scale factor for branch length distribution. This is used to create a weak prior for the amount of time each branch represents.")
 
     parser.add_argument('--steps',
                         default=1000,
@@ -290,7 +286,6 @@ def main():
 
     model_configuration = {
         "clock_rate":clock_rate, 
-        "variance_branch_length":args.variance_branch_length ,
         "variance_dates":args.variance_dates, 
         "expected_min_between_transmissions": args.expected_min_between_transmissions,
         "enforce_exact_clock": args.enforce_exact_clock,

--- a/src/chronumental/models.py
+++ b/src/chronumental/models.py
@@ -47,7 +47,7 @@ class DeltaGuideWithStrictLearntClock(ChronumentalModelBase):
     def __init__(self, **kwargs):
 
         self.clock_rate = kwargs['model_configuration']["clock_rate"]
-        self.variance_branch_length = kwargs['model_configuration']["variance_branch_length"]
+     
         self.variance_dates = kwargs['model_configuration']['variance_dates']
         self.enforce_exact_clock = kwargs['model_configuration']['enforce_exact_clock']
         self.variance_on_clock_rate = kwargs['model_configuration']['variance_on_clock_rate']
@@ -78,10 +78,8 @@ class DeltaGuideWithStrictLearntClock(ChronumentalModelBase):
 
         branch_times = numpyro.sample(
             "latent_time_length",
-            dist.TruncatedNormal(low=0,
-                                 loc=self.initial_time,
-                                 scale=self.variance_branch_length,
-                                 validate_args=True))
+            dist.Uniform(low=onp.ones(self.branch_distances_array.shape[0]) * 0,
+                            high=onp.ones(self.branch_distances_array.shape[0]) * 365*10000))
 
         if self.enforce_exact_clock:
             mutation_rate = self.clock_rate  


### PR DESCRIPTION
This parameter muddies the waters. It was originally added to scale the prior distribution for the branch lengths, and initially (wrongly) played quite a significant role in assignment. We realised that this didn't make sense, and decided to either relax it or to remove it (https://github.com/theosanderson/chronumental/issues/13). At that time we did some tuning experiments, comparing to TreeTime results, and found that a value of 10 performed a tiny fraction better than a value of 100 (but probably within random noise). At that time I decided to relax it to 10 rather than remove it entirely, based on that data. But upon receiving reviews for the paper I have decided to remove it both because
- the existence of this parameter causes confusion, because it makes the inference less clear
- it reduces the flexibility of the algorithm as it would exert a big effect if you tried to use Chronumental for data spanning centuries.

I have just some testing and shown that for the sort of datasets we're interested in it really makes almost no difference, and I'm sure in some cases things will work better without it.